### PR TITLE
Updating with new inventory references

### DIFF
--- a/dockerfiles/topia/self-contained/Dockerfile
+++ b/dockerfiles/topia/self-contained/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
   wget \
   tzdata \ 
   python3 \
+  sqlite3 \
   python3-dev \
   python3-pip \
   libcairo2-dev \

--- a/dockerfiles/topia/self-contained/entrypoint.sh
+++ b/dockerfiles/topia/self-contained/entrypoint.sh
@@ -7,6 +7,7 @@ touch $ENV_MARKET
 touch $ENV_HELPER
 
 echo "#!/bin/bash" >> $ENV_MARKET
+echo "export WORLD_NAME=topia"
 echo "export DB_HOST=$DB_HOST" >> $ENV_MARKET
 echo "export DB_USER=$DB_USER" >> $ENV_MARKET
 echo "export DB_PASS=$DB_PASS" >> $ENV_MARKET

--- a/dockerfiles/topia/slim/Dockerfile
+++ b/dockerfiles/topia/slim/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
   tree \ 
   wget \
   tzdata \
+  sqlite3 \
   libcairo2-dev
 
 RUN apt-get remove python3 -y

--- a/dockerfiles/topia/slim/entrypoint.sh
+++ b/dockerfiles/topia/slim/entrypoint.sh
@@ -7,6 +7,7 @@ touch $ENV_MARKET
 touch $ENV_HELPER
 
 echo "#!/bin/bash" >> $ENV_MARKET
+echo "export WORLD_NAME=topia"
 echo "export DB_HOST=$DB_HOST" >> $ENV_MARKET
 echo "export DB_USER=$DB_USER" >> $ENV_MARKET
 echo "export DB_PASS=$DB_PASS" >> $ENV_MARKET

--- a/scripts/world-cmd.sh
+++ b/scripts/world-cmd.sh
@@ -8,7 +8,7 @@ alias use='f(){ python -c "import inventory
 import sys
 inventory.items.use(\"$1\")" "$@"; unset -f f;}; f'
 alias inventory='f(){ python -c "import inventory
-inventory.list.display()"; unset -f f;}; f'
+inventory.registry.display()"; unset -f f;}; f'
 alias remove='f(){ python -c "import inventory
 import sys
 inventory.items.trash(\"$1\",\"$2\")" "$@"; unset -f f;}; f'


### PR DESCRIPTION
Inventory's main `API` is now referred to as `registry`; `bash` scripts need update.